### PR TITLE
check arguments for open backend

### DIFF
--- a/backends/open62541/src/import.c
+++ b/backends/open62541/src/import.c
@@ -10,6 +10,14 @@ int BackendOpen62541_addNamespace(void *userContext, const char *namespaceUri);
 bool NodesetLoader_loadFile(struct UA_Server *server, const char *path,
                             void *extensionHandling)
 {
+    if(!server)
+    {
+        return false;
+    }
+    if(!path)
+    {
+        return false;
+    }
     FileContext handler;
     handler.callback = BackendOpen62541_addNode;
     handler.addNamespace = BackendOpen62541_addNamespace;


### PR DESCRIPTION
fixes memleak when calling with a nullptr.