### PR TITLE
enable test with cycle detect again

### DIFF
--- a/src/Sort.c
+++ b/src/Sort.c
@@ -226,8 +226,34 @@ SortContext* Sort_init() {
     return ctx;
 }
 
+static void cleanupEdges(edge* e)
+{
+    edge* tmp=e;
+    while(tmp)
+    {
+        edge* next = tmp->next;
+        free(tmp);
+        tmp=next;
+    }
+}
+
+static void cleanupSubtree(node* n)
+{
+    if(!n)
+    {
+        return;
+    }
+    cleanupSubtree(n->left);
+    cleanupSubtree(n->right);
+    cleanupEdges(n->edges);
+    free(n);
+}
+
 void Sort_cleanup(SortContext* ctx) {
-    free(ctx->root1);
+    if(ctx->root1)
+    {
+        cleanupSubtree(ctx->root1);
+    }
     free(ctx);
 }
 
@@ -271,14 +297,9 @@ bool Sort_start(SortContext* ctx, struct Nodeset *nodeset, Sort_SortedNodeCallba
                     ctx->zeros->qlink = e->dest;
                     ctx->zeros = e->dest;
                 }
-                edge *tmp = e;
                 e = e->next;
-                free(tmp);
             }
-
-            node *tmp = ctx->head;
             ctx->head = ctx->head->qlink;
-            free(tmp);
         }
         if(ctx->keyCnt > 0) {
             printf("graph contains a loop\n");

--- a/src/Sort.c
+++ b/src/Sort.c
@@ -15,15 +15,17 @@
 #include <string.h>
 #define STREQ(a, b) (strcmp((a), (b)) == 0)
 
-struct edge {
+struct edge
+{
     struct node *dest;
     struct edge *next;
 };
 
 typedef struct edge edge;
 
-struct node {
-    const TNodeId* id;
+struct node
+{
+    const TNodeId *id;
     struct node *left, *right;
     int balance;
     struct node *qlink;
@@ -42,7 +44,8 @@ struct SortContext
     size_t keyCnt;
 };
 
-static node *new_node(const TNodeId* id) {
+static node *new_node(const TNodeId *id)
+{
     node *k = (node *)malloc(sizeof *k);
 
     k->id = id;
@@ -56,31 +59,34 @@ static node *new_node(const TNodeId* id) {
     return k;
 }
 
-static node *search_node(node *rootNode, const TNodeId* nodeId) {
+static node *search_node(node *rootNode, const TNodeId *nodeId)
+{
     node *p, *q, *r, *s, *t;
 
     assert(rootNode);
 
-    if(rootNode->right == NULL)
+    if (rootNode->right == NULL)
         return (rootNode->right = new_node(nodeId));
 
     t = rootNode;
     s = p = rootNode->right;
 
-    while(true) {
+    while (true)
+    {
         int a = TNodeId_cmp(nodeId, p->id);
-        if(a == 0)
+        if (a == 0)
             return p;
 
-        if(a < 0)
+        if (a < 0)
             q = p->left;
         else
             q = p->right;
 
-        if(q == NULL) {
+        if (q == NULL)
+        {
             q = new_node(nodeId);
 
-            if(a < 0)
+            if (a < 0)
                 p->left = q;
             else
                 p->right = q;
@@ -97,7 +103,8 @@ static node *search_node(node *rootNode, const TNodeId* nodeId) {
                 a = 1;
             }
 
-            while(p != q) {
+            while (p != q)
+            {
                 assert(TNodeId_cmp(nodeId, p->id));
                 if (TNodeId_cmp(nodeId, p->id) < 0)
                 {
@@ -111,29 +118,39 @@ static node *search_node(node *rootNode, const TNodeId* nodeId) {
                 }
             }
 
-            if(s->balance == 0 || s->balance == -a) {
+            if (s->balance == 0 || s->balance == -a)
+            {
                 s->balance += a;
                 return q;
             }
 
-            if(r->balance == a) {
+            if (r->balance == a)
+            {
                 p = r;
-                if(a < 0) {
+                if (a < 0)
+                {
                     s->left = r->right;
                     r->right = s;
-                } else {
+                }
+                else
+                {
                     s->right = r->left;
                     r->left = s;
                 }
                 s->balance = r->balance = 0;
-            } else {
-                if(a < 0) {
+            }
+            else
+            {
+                if (a < 0)
+                {
                     p = r->right;
                     r->right = p->left;
                     p->left = r;
                     s->left = p->right;
                     p->right = s;
-                } else {
+                }
+                else
+                {
                     p = r->left;
                     r->left = p->right;
                     p->right = r;
@@ -143,14 +160,14 @@ static node *search_node(node *rootNode, const TNodeId* nodeId) {
 
                 s->balance = 0;
                 r->balance = 0;
-                if(p->balance == a)
+                if (p->balance == a)
                     s->balance = -a;
-                else if(p->balance == -a)
+                else if (p->balance == -a)
                     r->balance = a;
                 p->balance = 0;
             }
 
-            if(s == t->right)
+            if (s == t->right)
                 t->right = p;
             else
                 t->left = p;
@@ -158,7 +175,8 @@ static node *search_node(node *rootNode, const TNodeId* nodeId) {
             return q;
         }
 
-        if(q->balance) {
+        if (q->balance)
+        {
             t = p;
             s = q;
         }
@@ -167,7 +185,8 @@ static node *search_node(node *rootNode, const TNodeId* nodeId) {
     }
 }
 
-static void record_relation(node *from, node *to) {
+static void record_relation(node *from, node *to)
+{
     struct edge *e;
 
     if (TNodeId_cmp(from->id, to->id))
@@ -180,14 +199,17 @@ static void record_relation(node *from, node *to) {
     }
 }
 
-static bool count_items(SortContext* ctx, node *unused) {
+static bool count_items(SortContext *ctx, node *unused)
+{
     ctx->keyCnt++;
     return false;
 }
 
-static bool scan_zeros(SortContext* ctx, node *k) {
-    if(k->edgeCount == 0 && k->id) {
-        if(ctx->head == NULL)
+static bool scan_zeros(SortContext *ctx, node *k)
+{
+    if (k->edgeCount == 0 && k->id)
+    {
+        if (ctx->head == NULL)
             ctx->head = k;
         else
             ctx->zeros->qlink = k;
@@ -198,48 +220,54 @@ static bool scan_zeros(SortContext* ctx, node *k) {
     return false;
 }
 
-static bool recurse_tree(SortContext* ctx, node *rootNode, bool (*action)(SortContext* ctx, node *)) {
-    if(rootNode->left == NULL && rootNode->right == NULL)
+static bool recurse_tree(SortContext *ctx, node *rootNode,
+                         bool (*action)(SortContext *ctx, node *))
+{
+    if (rootNode->left == NULL && rootNode->right == NULL)
         return (*action)(ctx, rootNode);
-    else {
-        if(rootNode->left != NULL)
-            if(recurse_tree(ctx, rootNode->left, action))
+    else
+    {
+        if (rootNode->left != NULL)
+            if (recurse_tree(ctx, rootNode->left, action))
                 return true;
-        if((*action)(ctx, rootNode))
+        if ((*action)(ctx, rootNode))
             return true;
-        if(rootNode->right != NULL)
-            if(recurse_tree(ctx, rootNode->right, action))
+        if (rootNode->right != NULL)
+            if (recurse_tree(ctx, rootNode->right, action))
                 return true;
     }
 
     return false;
 }
 
-static void walk_tree(SortContext* ctx, node *rootNode, bool (*action)(SortContext* ctx, node *)) {
-    if(rootNode->right)
+static void walk_tree(SortContext *ctx, node *rootNode,
+                      bool (*action)(SortContext *ctx, node *))
+{
+    if (rootNode->right)
         recurse_tree(ctx, rootNode->right, action);
 }
 
-SortContext* Sort_init() { 
-    SortContext* ctx = (SortContext*) calloc(1, sizeof(SortContext));
+SortContext *Sort_init()
+{
+    SortContext *ctx = (SortContext *)calloc(1, sizeof(SortContext));
     ctx->root1 = new_node(NULL);
     return ctx;
 }
 
-static void cleanupEdges(edge* e)
+static void cleanupEdges(edge *e)
 {
-    edge* tmp=e;
-    while(tmp)
+    edge *tmp = e;
+    while (tmp)
     {
-        edge* next = tmp->next;
+        edge *next = tmp->next;
         free(tmp);
-        tmp=next;
+        tmp = next;
     }
 }
 
-static void cleanupSubtree(node* n)
+static void cleanupSubtree(node *n)
 {
-    if(!n)
+    if (!n)
     {
         return;
     }
@@ -249,23 +277,26 @@ static void cleanupSubtree(node* n)
     free(n);
 }
 
-void Sort_cleanup(SortContext* ctx) {
-    if(ctx->root1)
+void Sort_cleanup(SortContext *ctx)
+{
+    if (ctx->root1)
     {
         cleanupSubtree(ctx->root1);
     }
     free(ctx);
 }
 
-void Sort_addNode(SortContext* ctx, TNode *data)
+void Sort_addNode(SortContext *ctx, TNode *data)
 {
     node *j = NULL;
-    //add node, no matter if there are references on it
+    // add node, no matter if there are references on it
     j = search_node(ctx->root1, &data->id);
     j->data = data;
     Reference *hierachicalRef = data->hierachicalRefs;
-    while(hierachicalRef) {
-        if(!hierachicalRef->isForward) {
+    while (hierachicalRef)
+    {
+        if (!hierachicalRef->isForward)
+        {
 
             node *k = search_node(ctx->root1, &hierachicalRef->target);
             record_relation(k, j);
@@ -274,26 +305,32 @@ void Sort_addNode(SortContext* ctx, TNode *data)
     }
 }
 
-bool Sort_start(SortContext* ctx, struct Nodeset *nodeset, Sort_SortedNodeCallback callback)
+bool Sort_start(SortContext *ctx, struct Nodeset *nodeset,
+                Sort_SortedNodeCallback callback)
 {
     walk_tree(ctx, ctx->root1, count_items);
 
-    while(ctx->keyCnt > 0) {
+    while (ctx->keyCnt > 0)
+    {
         walk_tree(ctx, ctx->root1, scan_zeros);
 
-        while(ctx->head) {
+        while (ctx->head)
+        {
             edge *e = ctx->head->edges;
 
-            if(ctx->head->data != NULL) {
+            if (ctx->head->data != NULL)
+            {
                 callback(nodeset, ctx->head->data);
             }
 
             ctx->head->id = NULL;
             ctx->keyCnt--;
 
-            while(e) {
+            while (e)
+            {
                 e->dest->edgeCount--;
-                if(e->dest->edgeCount == 0) {
+                if (e->dest->edgeCount == 0)
+                {
                     ctx->zeros->qlink = e->dest;
                     ctx->zeros = e->dest;
                 }
@@ -301,7 +338,8 @@ bool Sort_start(SortContext* ctx, struct Nodeset *nodeset, Sort_SortedNodeCallba
             }
             ctx->head = ctx->head->qlink;
         }
-        if(ctx->keyCnt > 0) {
+        if (ctx->keyCnt > 0)
+        {
             printf("graph contains a loop\n");
             return false;
         }

--- a/tests/sort.c
+++ b/tests/sort.c
@@ -127,40 +127,38 @@ END_TEST
 //todo: fix this test, memleak in sort nodes
 // cycle nodeB -> nodeA and NodeA -> NodeB
 // expect: cycle detection
-/*
-TEST(sort, cycle) {
+START_TEST(cycleDetect) {
     sortedNodesCnt = 0;
-    init();
+    SortContext *ctx = Sort_init();
 
     TNode a;
-
-    TNodeId idb;
-    idb.idString = (char*)"nodeB";
-    idb.nsIdx = 1;
-    idb.id = (char *)"test";
-
-    Reference refb;
-    refb.isForward = false;
-    refb.target = idb;
-    refb.next = NULL;
-
-    a.hierachicalRefs = &refb;
-    a.id.idString = (char *)"nodeA";
-
-    Reference ref;
-    ref.isForward = false;
-    ref.target = a.id;
-    ref.next = NULL;
+    a.id.nsIdx = 1;
+    a.id.id = "nodeA";
 
     TNode b;
-    b.hierachicalRefs = &ref;
-    b.id.idString = (char *)"nodeB";
+    b.id.id = "nodeB";
+    b.id.nsIdx = 1;
 
-    addNodeToSort(&b);
-    addNodeToSort(&a);
-    sort(NULL, sortCallback);
+    Reference ref_AToB;
+    ref_AToB.isForward = false;
+    ref_AToB.target = b.id;
+    ref_AToB.next = NULL;
+
+    a.hierachicalRefs = &ref_AToB;
+
+    Reference ref_BToA;
+    ref_BToA.isForward = false;
+    ref_BToA.target = a.id;
+    ref_BToA.next = NULL;
+
+    b.hierachicalRefs = &ref_BToA;
+
+    Sort_addNode(ctx, &b);
+    Sort_addNode(ctx, &a);
+    ck_assert(!Sort_start(ctx, NULL, sortCallback));
+    Sort_cleanup(ctx);
 }
-*/
+END_TEST
 
 START_TEST(empty)
 {
@@ -177,7 +175,7 @@ int main(void) {
     tcase_add_test(tc, sortNodes);
     tcase_add_test(tc, nodeWithRefs_1);
     tcase_add_test(tc, nodeWithRefs_2);
-    //tcase_add_test(tc, cycle);
+    tcase_add_test(tc, cycleDetect);
     tcase_add_test(tc, empty);
     suite_add_tcase(s, tc);
 


### PR DESCRIPTION
this PR also refactors the cleaning up of the binary sorting tree. Now the nodes are cleaned up after sorting them, no matter if sorting was successful or fails. The cleanup is done via a recursion, if this leads to problems on large nodesets, the recursion should unrolled.