### PR TITLE
use UA_NodeId_parse from sdk

### DIFF
--- a/backends/open62541/src/conversion.h
+++ b/backends/open62541/src/conversion.h
@@ -30,87 +30,41 @@ static inline UA_Boolean isTrue(const char *s)
     return UA_TRUE;
 }
 
-static inline UA_NodeId getNodeIdFromChars(TNodeId id)
+static inline UA_NodeId getNodeIdFromChars(TNodeId tid)
 {
-    if (!id.id)
+    UA_NodeId id = UA_NODEID_NULL;
+    if (!tid.id)
     {
         return UA_NODEID_NULL;
     }
-    UA_UInt16 nsidx = (UA_UInt16)id.nsIdx;
-
-    switch (id.id[0])
+    UA_String idString;
+    idString.length = strlen(tid.id);
+    idString.data = (UA_Byte*)tid.id;
+    UA_StatusCode result = UA_NodeId_parse(&id, idString);
+    if (result != UA_STATUSCODE_GOOD)
     {
-    // integer
-    case 'i':
-    {
-        UA_UInt32 nodeId = (UA_UInt32)atoi(&id.id[2]);
-        return UA_NODEID_NUMERIC(nsidx, nodeId);
-        break;
-    }
-    case 's':
-    {
-        return UA_NODEID_STRING_ALLOC(nsidx, &id.id[2]);
-        break;
-    }
-    }
-    return UA_NODEID_NULL;
-}
-
-// todo: handle guid, bytestring
-static inline UA_NodeId extractNodeId(char *s)
-{
-    if (!s || strlen(s) < 3)
-    {
-        return UA_NODEID_NULL;
-    }
-    char *idxSemi = strchr(s, ';');
-    // namespaceindex zero?
-    if (idxSemi == NULL)
-    {
-        switch (s[0])
-        {
-        // integer
-        case 'i':
-        {
-            UA_UInt32 nodeId = (UA_UInt32)atoi(&s[2]);
-            return UA_NODEID_NUMERIC(0, nodeId);
-        }
-        case 's':
-        {
-            return UA_NODEID_STRING_ALLOC(0, &s[2]);
-        }
-        }
-    }
-    else
-    {
-        UA_NodeId id;
-        id.namespaceIndex = 0;
-        UA_UInt16 nsIdx = (UA_UInt16)atoi(&s[3]);
-        switch (idxSemi[1])
-        {
-        // integer
-        case 'i':
-        {
-            UA_UInt32 nodeId = (UA_UInt32)atoi(&idxSemi[3]);
-            id.namespaceIndex = nsIdx;
-            id.identifierType = UA_NODEIDTYPE_NUMERIC;
-            id.identifier.numeric = nodeId;
-            break;
-        }
-        case 's':
-        {
-            UA_String sid = UA_STRING_ALLOC(&idxSemi[3]);
-            id.namespaceIndex = nsIdx;
-            id.identifierType = UA_NODEIDTYPE_STRING;
-            id.identifier.string = sid;
-            break;
-        }
-        default:
-            return UA_NODEID_NULL;
-        }
         return id;
     }
-    return UA_NODEID_NULL;
+    id.namespaceIndex = (UA_UInt16)tid.nsIdx;
+    return id;
+}
+
+static inline UA_NodeId extractNodeId(char *s)
+{
+    UA_NodeId id = UA_NODEID_NULL;
+    if(!s)
+    {
+        return id;
+    }    
+    UA_String idString;
+    idString.length=strlen(s);
+    idString.data = (UA_Byte*)s;
+    UA_StatusCode result = UA_NodeId_parse(&id, idString);
+    if(result!=UA_STATUSCODE_GOOD)
+    {
+        return id;
+    }
+    return id;
 }
 
 #endif


### PR DESCRIPTION
to get rid of the handwritten conversion routines.

Build only with the current master of open.