### PR TITLE
Link libxml2 to target nodesetloader with PUBLIC flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ target_include_directories(NodesetLoader
     PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src ${LIBXML2_INCLUDE_DIRS})
-target_link_libraries(NodesetLoader PRIVATE ${LIBXML2_LIBRARIES})
+target_link_libraries(NodesetLoader PUBLIC ${LIBXML2_LIBRARIES})
 if(${CALC_COVERAGE})
     target_link_libraries(NodesetLoader PUBLIC coverageLib)
 endif()


### PR DESCRIPTION
The PUBLIC flag puts libxml2 in the link interface of the
nodesetloader target which enables targets that links to nodesetloader
to also link to libxml2.

#143