### PR TITLE
Resolved undefined behavior for isspace

### DIFF
--- a/src/Value.c
+++ b/src/Value.c
@@ -139,7 +139,7 @@ static const char* isOnlyWhitespace(const char* value)
     }
     for(const char* c=value;*c!='\0'; c++)
     {
-        if(!isspace(*c))
+        if(!isspace((unsigned char)*c))
         {
             return value;
         }

--- a/src/Value.c
+++ b/src/Value.c
@@ -139,6 +139,7 @@ static const char* isOnlyWhitespace(const char* value)
     }
     for(const char* c=value;*c!='\0'; c++)
     {
+        // http://www.cplusplus.com/reference/cctype/isspace/
         if(!isspace((unsigned char)*c))
         {
             return value;


### PR DESCRIPTION
The value passed to isspace must be representable as an
unsigned char (or EOF) according to the C99 standard. The
behavior for other values is undefined.
This could cause problems for char values > 127 depending on
the signedness of char.