### PR TITLE
Switch field in unions shall not count as a member

### DIFF
--- a/backends/open62541/src/DataTypeImporter.c
+++ b/backends/open62541/src/DataTypeImporter.c
@@ -247,7 +247,6 @@ static void setPaddingMemsize(UA_DataType *type,
         type->memSize = (UA_UInt16)(type->memSize + biggestMemberSize);
         endPadding = getPadding(alignof(size_t), type->memSize);
         type->memSize = (UA_UInt16)(type->memSize + endPadding);
-        type->membersSize++;
     }
     else
     {


### PR DESCRIPTION
The switch field in a union shall not increment the member size
as no type is added for that field.