### PR TITLE
Enum value parsing now handling both possible formats

### DIFF
--- a/backends/open62541/src/Value.c
+++ b/backends/open62541/src/Value.c
@@ -229,6 +229,17 @@ static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *da
 static void setArray(const NL_Data *value, const UA_DataType *type, RawData *data,
                      const UA_DataType *customTypes);
 
+static const char* getEnumValuePos(const char *string)
+{
+    // Enum value is either on <symbol>_<value> or <value> format
+    char *enumSepPos = strchr(string, '_');
+    if (enumSepPos)
+    {
+        return ++enumSepPos;
+    }
+    return string;
+}
+
 #ifdef USE_MEMBERTYPE_INDEX
 static const UA_DataType* getMemberType(const UA_DataTypeMember* m, const UA_DataType* customTypes)
 {
@@ -319,7 +330,7 @@ static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *da
     }
     else if (type->typeKind == UA_DATATYPEKIND_ENUM)
     {
-        setPrimitiveValue(data, value->val.primitiveData.value,
+        setPrimitiveValue(data, getEnumValuePos(value->val.primitiveData.value),
                           UA_DATATYPEKIND_INT32,
                           UA_TYPES[UA_TYPES_INT32].memSize);
     }
@@ -361,7 +372,7 @@ RawData *Value_getData(const NL_Value *value, const UA_DataType *type,
         {
             data->mem =
                 calloc(value->data->val.complexData.membersSize, type->memSize);
-            setArray(value->data, type, data, customTypes);            
+            setArray(value->data, type, data, customTypes);
         }
     }
     else


### PR DESCRIPTION
The enum value may either be on \<symbol\>_\<value\> or \<value\> format
depending on if it's part of a struct or not.