### PR TITLE
Limit known type range to built in types only

### DIFF
--- a/backends/open62541/src/import.c
+++ b/backends/open62541/src/import.c
@@ -40,7 +40,7 @@ static bool isKnownParent(const UA_NodeId typeId)
 {
     if (typeId.namespaceIndex == 0 &&
         typeId.identifierType == UA_NODEIDTYPE_NUMERIC &&
-        typeId.identifier.numeric <= 25)
+        typeId.identifier.numeric <= 29)
     {
         return true;
     }

--- a/backends/open62541/src/import.c
+++ b/backends/open62541/src/import.c
@@ -40,7 +40,7 @@ static bool isKnownParent(const UA_NodeId typeId)
 {
     if (typeId.namespaceIndex == 0 &&
         typeId.identifierType == UA_NODEIDTYPE_NUMERIC &&
-        typeId.identifier.numeric <= 30)
+        typeId.identifier.numeric <= 25)
     {
         return true;
     }


### PR DESCRIPTION
E.g. Image was incorrectly flagged as a known type but subsequent calls to UA_findDataType() failed as Image isn't represented in UA_TYPES.