### PR TITLE
Support GUID values in the open62541 backend.

### DIFF
--- a/backends/open62541/src/Value.c
+++ b/backends/open62541/src/Value.c
@@ -224,6 +224,13 @@ static void setByteString(const NL_Data* value, RawData*data)
     data->additionalMem = val;
 }
 
+static void setGuid(const NL_Data* value, RawData*data)
+{
+    uintptr_t adr = (uintptr_t)data->mem + data->offset;
+    *(UA_Guid*)adr = UA_GUID((const char *)(value->val.complexData.members[0]->val.primitiveData.value));
+    data->offset = data->offset + sizeof(UA_Guid);
+}
+
 static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *data,
                       const UA_DataType *customTypes);
 static void setArray(const NL_Data *value, const UA_DataType *type, RawData *data,
@@ -326,6 +333,10 @@ static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *da
     else if (type->typeKind == UA_DATATYPEKIND_STRUCTURE)
     {
         setStructure(value, type, data, customTypes);
+    }
+    else if (type->typeKind == UA_DATATYPEKIND_GUID)
+    {
+        setGuid(value, data);
     }
     else
     {

--- a/backends/open62541/tests/namespaceZeroValues.c
+++ b/backends/open62541/tests/namespaceZeroValues.c
@@ -100,6 +100,13 @@ START_TEST(Server_LoadNS0Values) {
     ck_assert(var.type == &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
     ck_assert_uint_eq(((UA_QualifiedName *)var.data)->namespaceIndex, 2);
     UA_Variant_clear(&var);
+    // Guid
+    UA_Guid guid = UA_GUID("72962B91-FA75-4AE6-8D28-B404DC7DAF63");
+    retval = UA_Server_readValue(server, UA_NODEID_NUMERIC(nsIdx, 1011), &var);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(var.type == &UA_TYPES[UA_TYPES_GUID]);
+    ck_assert(UA_Guid_equal(&guid, (UA_Guid *)var.data));
+    UA_Variant_clear(&var);
 }
 END_TEST
 

--- a/backends/open62541/tests/namespaceZeroValues.xml
+++ b/backends/open62541/tests/namespaceZeroValues.xml
@@ -21,6 +21,7 @@
         <Alias Alias="LocalizedText">i=21</Alias>
         <Alias Alias="QualifiedName">i=20</Alias>
         <Alias Alias="EnumValueType">i=7594</Alias>
+        <Alias Alias="Guid">i=14</Alias>
     </Aliases>
    <UAVariable NodeId="ns=1;i=1000" BrowseName="InputArguments" DataType="i=296" ValueRank="1" ArrayDimensions="0">
     <DisplayName>Arguments_Array</DisplayName>
@@ -340,6 +341,18 @@
             </uax:ListOfExtensionObject>
         </Value>
     </UAVariable>
+  <UAVariable NodeId="ns=1;i=1011" BrowseName="Guid" DataType="Guid" ValueRank="-1">
+    <DisplayName>Guid</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=85</Reference>
+    </References>
+    <Value>
+      <uax:Guid>
+        <uax:String>72962B91-FA75-4AE6-8D28-B404DC7DAF63</uax:String>
+      </uax:Guid>
+    </Value>
+  </UAVariable>
     <UAVariable NodeId="ns=1;i=15007" BrowseName="StaticNumericNodeIdRange" DataType="i=291" ValueRank="1" ArrayDimensions="0">
     <DisplayName>StaticNumericNodeIdRange</DisplayName>
     <References>


### PR DESCRIPTION
Guid values have not been supported yet. This PR adds them.
BTW. there are still a few standard DataTypes not supported. I will work next on Unions as I need them for my use case.