### PR TITLE
Translate namespace indices in values.

### DIFF
--- a/backends/open62541/CMakeLists.txt
+++ b/backends/open62541/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(NodesetLoader
         ${CMAKE_CURRENT_SOURCE_DIR}/src/DataTypeImporter.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/customDataType.c
         ${CMAKE_CURRENT_SOURCE_DIR}/src/RefServiceImpl.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ServerContext.c
 )
 
 target_include_directories(NodesetLoader PUBLIC 

--- a/backends/open62541/src/ServerContext.c
+++ b/backends/open62541/src/ServerContext.c
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2021 (c) Jan Murzyn
+ */
+
+#include "ServerContext.h"
+
+typedef struct UA_Server UA_Server;
+
+struct ServerContext
+{
+    UA_Server *server;
+    size_t namespaceCnt;
+    UA_UInt16 *namespaceIdxMapping;
+};
+
+ServerContext *ServerContext_new(UA_Server *server)
+{
+    ServerContext *serverContext = (ServerContext *)calloc(1, sizeof(ServerContext));
+    if (serverContext)
+    {
+        serverContext->server = server;
+        serverContext->namespaceCnt = 0;
+        serverContext->namespaceIdxMapping = NULL;
+    }
+
+    return serverContext;
+}
+
+void ServerContext_delete(ServerContext *serverContext)
+{
+    free(serverContext->namespaceIdxMapping);
+    free(serverContext);
+}
+
+UA_Server *ServerContext_getServerObject(const ServerContext *serverContext)
+{
+    if (!serverContext)
+        return NULL;
+
+    return serverContext->server;
+}
+
+// Adding server side namespace indices to an array of UA_UInt16.
+// Position in the array (minus 1) corresponds to the namespace index in the nodeset file. 
+// E.g.
+// namespaceIdxMapping [0] = x
+//                     [1] = y
+//                     [2] = z
+//                     ...
+// y is a server side namespace index of the namespace that in the nodeset file has index 2. 
+void ServerContext_addNamespaceIdx(ServerContext *serverContext, UA_UInt16 serverIdx)
+{
+    if (!serverContext)
+        return;
+
+    void *newNamespaceIdxMapping =
+        realloc(serverContext->namespaceIdxMapping, sizeof(UA_UInt16) * serverContext->namespaceCnt + 1 );
+    
+    if (newNamespaceIdxMapping)
+    {
+        serverContext->namespaceIdxMapping = (UA_UInt16 *)newNamespaceIdxMapping;
+        serverContext->namespaceCnt++;
+        serverContext->namespaceIdxMapping[serverContext->namespaceCnt - 1] = serverIdx;
+    }
+}
+
+// See the comment above ServerContext_addNamespaceIdx
+UA_UInt16 ServerContext_translateToServerIdx(const ServerContext *serverContext, UA_UInt16 nodesetIdx)
+{
+    if (!serverContext)
+        return UA_UINT16_MAX;
+
+    if ((nodesetIdx > 0) && ((size_t)nodesetIdx <= serverContext->namespaceCnt))
+    {
+        return serverContext->namespaceIdxMapping[nodesetIdx - 1];
+    }
+    else
+    {
+        return UA_UINT16_MAX;
+    }
+}

--- a/backends/open62541/src/ServerContext.c
+++ b/backends/open62541/src/ServerContext.c
@@ -57,7 +57,7 @@ void ServerContext_addNamespaceIdx(ServerContext *serverContext, UA_UInt16 serve
         return;
 
     void *newNamespaceIdxMapping =
-        realloc(serverContext->namespaceIdxMapping, sizeof(UA_UInt16) * serverContext->namespaceCnt + 1 );
+        realloc(serverContext->namespaceIdxMapping, sizeof(UA_UInt16) * (serverContext->namespaceCnt + 1));
     
     if (newNamespaceIdxMapping)
     {

--- a/backends/open62541/src/ServerContext.c
+++ b/backends/open62541/src/ServerContext.c
@@ -73,12 +73,18 @@ UA_UInt16 ServerContext_translateToServerIdx(const ServerContext *serverContext,
     if (!serverContext)
         return UA_UINT16_MAX;
 
-    if ((nodesetIdx > 0) && ((size_t)nodesetIdx <= serverContext->namespaceCnt))
+    if (nodesetIdx == 0)
+    {
+        // Zero is always 0, no need for translation
+        return 0;
+    }
+    else if ((nodesetIdx > 0) && ((size_t)nodesetIdx <= serverContext->namespaceCnt))
     {
         return serverContext->namespaceIdxMapping[nodesetIdx - 1];
     }
     else
     {
+        // Error case. Should it rather be handled by assert(false)?
         return UA_UINT16_MAX;
     }
 }

--- a/backends/open62541/src/ServerContext.h
+++ b/backends/open62541/src/ServerContext.h
@@ -1,0 +1,36 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ *    Copyright 2021 (c) Jan Murzyn
+ */
+
+#ifndef SERVERCONTEXT_H
+#define SERVERCONTEXT_H
+
+#include <open62541/types.h>
+
+struct UA_Server;
+
+// ServerContext struct bundles the open62541's UA_Server object
+// and a table that maps indices used in the nodeset file to indices used in the server.
+struct ServerContext;
+typedef struct ServerContext ServerContext;
+
+// ServerContext_new allocates memory that has to released by ServerContext_delete
+ServerContext *ServerContext_new(struct UA_Server *server);
+
+// Releases memory allocated by ServerContext_new
+void ServerContext_delete(ServerContext *serverContext);
+
+// Gets pointer to the UA_Server object
+struct UA_Server *ServerContext_getServerObject(const ServerContext *serverContext);
+
+// Use ServerContext_addNamespaceIdx to sequentially add namespaces as they appear in the
+// nodeset file.
+void ServerContext_addNamespaceIdx(ServerContext *serverContext, UA_UInt16 serverIdx);
+
+// Translates from an index used in the nodeset file to an index used in the server
+UA_UInt16 ServerContext_translateToServerIdx(const ServerContext *serverContext, UA_UInt16 nodesetIdx);
+
+#endif

--- a/backends/open62541/src/Value.c
+++ b/backends/open62541/src/Value.c
@@ -11,6 +11,7 @@
 #include <assert.h>
 #include <open62541/types_generated.h>
 #include "base64.h"
+#include "ServerContext.h"
 
 typedef struct TypeList TypeList;
 struct TypeList
@@ -158,17 +159,21 @@ static void setDateTime(const NL_Data *value, RawData *data)
     data->offset = data->offset + sizeof(UA_DateTime);
 }
 
-static void setQualifiedName(const NL_Data *value, RawData *data)
+static void setQualifiedName(const NL_Data *value, RawData *data, const ServerContext *serverContext)
 {
+    uintptr_t adr = (uintptr_t)data->mem + data->offset;
 
     setScalarValueWithAddress(
-        data->offset + (uintptr_t) &
-            ((UA_QualifiedName *)data->mem)->namespaceIndex,
+        (uintptr_t)&((UA_QualifiedName*)adr)->namespaceIndex,
         UA_DATATYPEKIND_UINT16,
         value->val.complexData.members[0]->val.primitiveData.value);
+    
+    // Translate namespace index
+    ((UA_QualifiedName*)adr)->namespaceIndex = 
+        ServerContext_translateToServerIdx(serverContext, ((UA_QualifiedName*)adr)->namespaceIndex);        
 
     setScalarValueWithAddress(
-        data->offset + (uintptr_t) & ((UA_QualifiedName *)data->mem)->name,
+        (uintptr_t)&((UA_QualifiedName*)adr)->name,
         UA_DATATYPEKIND_STRING,
         value->val.complexData.members[1]->val.primitiveData.value);
 
@@ -198,13 +203,17 @@ static void setLocalizedText(const NL_Data *value, RawData *data)
     data->offset += sizeof(UA_LocalizedText);
 }
 
-static void setNodeId(const NL_Data *value, RawData *data)
+static void setNodeId(const NL_Data *value, RawData *data, const ServerContext *serverContext)
 {
-    // TODO: translate namespaceIndex?
     assert(value->val.complexData.membersSize == 1);
     *(UA_NodeId *)((uintptr_t)data->mem + data->offset) =
         extractNodeId((char *)(uintptr_t)value->val.complexData.members[0]
                           ->val.primitiveData.value);
+
+    // Translate namespace index
+    (*(UA_NodeId *)((uintptr_t)data->mem + data->offset)).namespaceIndex =
+        ServerContext_translateToServerIdx(serverContext, (*(UA_NodeId *)((uintptr_t)data->mem + data->offset)).namespaceIndex);
+
     data->offset += sizeof(UA_NodeId);
 }
 
@@ -225,9 +234,9 @@ static void setByteString(const NL_Data* value, RawData*data)
 }
 
 static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *data,
-                      const UA_DataType *customTypes);
+                      const UA_DataType *customTypes, const ServerContext *serverContext);
 static void setArray(const NL_Data *value, const UA_DataType *type, RawData *data,
-                     const UA_DataType *customTypes);
+                     const UA_DataType *customTypes, const ServerContext *serverContext);
 
 #ifdef USE_MEMBERTYPE_INDEX
 static const UA_DataType* getMemberType(const UA_DataTypeMember* m, const UA_DataType* customTypes)
@@ -253,7 +262,7 @@ static const UA_DataType *getMemberType(const UA_DataTypeMember *m, const UA_Dat
 #endif
 
 static void setStructure(const NL_Data *value, const UA_DataType *type,
-                         RawData *data, const UA_DataType *customTypes)
+                         RawData *data, const UA_DataType *customTypes, const ServerContext *serverContext)
 {
     assert(value->type == DATATYPE_COMPLEX);
     // there can be less members specified then the type requires
@@ -274,7 +283,7 @@ static void setStructure(const NL_Data *value, const UA_DataType *type,
             RawData *rawdata = RawData_new(data);
             rawdata->mem = calloc(memberData->val.complexData.membersSize,
                                   memberType->memSize);
-            setArray(memberData, memberType, rawdata, customTypes);
+            setArray(memberData, memberType, rawdata, customTypes, serverContext);
             size_t *size = (size_t *)((uintptr_t)data->mem + data->offset);
             *size = memberData->val.complexData.membersSize;
             data->offset += sizeof(size_t);
@@ -284,13 +293,13 @@ static void setStructure(const NL_Data *value, const UA_DataType *type,
         }
         else
         {
-            setScalar(memberData, memberType, data, customTypes);
+            setScalar(memberData, memberType, data, customTypes, serverContext);
         }
     }
 }
 
 static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *data,
-                      const UA_DataType *customTypes)
+                      const UA_DataType *customTypes, const ServerContext *serverContext)
 {
     if (type->typeKind < CONVERSION_TABLE_SIZE)
     {
@@ -303,11 +312,11 @@ static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *da
     }
     else if (type->typeKind == UA_DATATYPEKIND_NODEID)
     {
-        setNodeId(value, data);
+        setNodeId(value, data, serverContext);
     }
     else if (type->typeKind == UA_DATATYPEKIND_QUALIFIEDNAME)
     {
-        setQualifiedName(value, data);
+        setQualifiedName(value, data, serverContext);
     }
     else if (type->typeKind == UA_DATATYPEKIND_LOCALIZEDTEXT)
     {
@@ -325,7 +334,7 @@ static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *da
     }
     else if (type->typeKind == UA_DATATYPEKIND_STRUCTURE)
     {
-        setStructure(value, type, data, customTypes);
+        setStructure(value, type, data, customTypes, serverContext);
     }
     else
     {
@@ -334,16 +343,16 @@ static void setScalar(const NL_Data *value, const UA_DataType *type, RawData *da
 }
 
 static void setArray(const NL_Data *value, const UA_DataType *type, RawData *data,
-                     const UA_DataType *customTypes)
+                     const UA_DataType *customTypes, const ServerContext *serverContext)
 {
     for (size_t i = 0; i < value->val.complexData.membersSize; i++)
     {
-        setScalar(value->val.complexData.members[i], type, data, customTypes);
+        setScalar(value->val.complexData.members[i], type, data, customTypes, serverContext);
     }
 }
 
 RawData *Value_getData(const NL_Value *value, const UA_DataType *type,
-                       const UA_DataType *customTypes)
+                       const UA_DataType *customTypes, const ServerContext *serverContext)
 {
     if (!type)
     {
@@ -361,13 +370,13 @@ RawData *Value_getData(const NL_Value *value, const UA_DataType *type,
         {
             data->mem =
                 calloc(value->data->val.complexData.membersSize, type->memSize);
-            setArray(value->data, type, data, customTypes);            
+            setArray(value->data, type, data, customTypes, serverContext);            
         }
     }
     else
     {
         data->mem = calloc(1, type->memSize);
-        setScalar(value->data, type, data, customTypes);
+        setScalar(value->data, type, data, customTypes, serverContext);
     }
 
     return data;

--- a/backends/open62541/src/Value.h
+++ b/backends/open62541/src/Value.h
@@ -10,6 +10,8 @@
 #include <open62541/types.h>
 #include <NodesetLoader/NodesetLoader.h>
 
+struct ServerContext;
+
 struct RawData;
 struct RawData
 {
@@ -22,6 +24,6 @@ struct RawData
 typedef struct RawData RawData;
 void RawData_delete(RawData *data);
 
-RawData *Value_getData(const NL_Value *value, const UA_DataType* type, const UA_DataType* customTypes);
+RawData *Value_getData(const NL_Value *value, const UA_DataType* type, const UA_DataType* customTypes, const struct ServerContext *serverContext);
 
 #endif

--- a/backends/open62541/tests/namespaceZeroValues.c
+++ b/backends/open62541/tests/namespaceZeroValues.c
@@ -108,6 +108,13 @@ START_TEST(Server_LoadNS0Values) {
     ck_assert(var.type == &UA_TYPES[UA_TYPES_NODEID]);
     ck_assert(UA_NodeId_equal(&nodeId, (UA_NodeId *)var.data));
     UA_Variant_clear(&var);
+    // NodeId (NS0)
+    UA_NodeId nodeIdNs0 = UA_NODEID_NUMERIC(0, 1234);
+    retval = UA_Server_readValue(server, UA_NODEID_NUMERIC(nsIdx, 1013), &var);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(var.type == &UA_TYPES[UA_TYPES_NODEID]);
+    ck_assert(UA_NodeId_equal(&nodeIdNs0, (UA_NodeId *)var.data));
+    UA_Variant_clear(&var);
     // Guid
     UA_Guid guid = UA_GUID("72962B91-FA75-4AE6-8D28-B404DC7DAF63");
     retval = UA_Server_readValue(server, UA_NODEID_NUMERIC(nsIdx, 1011), &var);

--- a/backends/open62541/tests/namespaceZeroValues.c
+++ b/backends/open62541/tests/namespaceZeroValues.c
@@ -95,10 +95,18 @@ START_TEST(Server_LoadNS0Values) {
     ck_assert(UA_String_equal(&((UA_LocalizedText*)var.data)[1].text, &s));
     UA_Variant_clear(&var);
     // QualifiedName
+    UA_QualifiedName qualifiedName = UA_QUALIFIEDNAME(2, "qualifiedName");
     retval = UA_Server_readValue(server, UA_NODEID_NUMERIC(nsIdx, 1009), &var);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
     ck_assert(var.type == &UA_TYPES[UA_TYPES_QUALIFIEDNAME]);
-    ck_assert_uint_eq(((UA_QualifiedName *)var.data)->namespaceIndex, 2);
+    ck_assert(UA_QualifiedName_equal(&qualifiedName, (UA_QualifiedName *)var.data));
+    UA_Variant_clear(&var);
+    // NodeId
+    UA_NodeId nodeId = UA_NODEID_NUMERIC(2, 1234);
+    retval = UA_Server_readValue(server, UA_NODEID_NUMERIC(nsIdx, 1012), &var);
+    ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
+    ck_assert(var.type == &UA_TYPES[UA_TYPES_NODEID]);
+    ck_assert(UA_NodeId_equal(&nodeId, (UA_NodeId *)var.data));
     UA_Variant_clear(&var);
 }
 END_TEST

--- a/backends/open62541/tests/namespaceZeroValues.xml
+++ b/backends/open62541/tests/namespaceZeroValues.xml
@@ -298,18 +298,6 @@
       </uax:QualifiedName>
     </Value>
   </UAVariable>
-  <UAVariable NodeId="ns=1;i=1012" BrowseName="NodeId" DataType="NodeId" ValueRank="-1">
-    <DisplayName>NodeId</DisplayName>
-    <References>
-      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
-      <Reference ReferenceType="HasComponent" IsForward="false">i=85</Reference>
-    </References>
-    <Value>
-      <uax:NodeId>
-        <uax:Identifier>ns=1;i=1234</uax:Identifier>
-      </uax:NodeId>
-    </Value>
-  </UAVariable>  
   <UAVariable DataType="EnumValueType" ValueRank="1" NodeId="ns=1;i=1010" ArrayDimensions="2" BrowseName="EnumValues">
         <DisplayName>EnumValues</DisplayName>
         <References>
@@ -364,6 +352,30 @@
       <uax:Guid>
         <uax:String>72962B91-FA75-4AE6-8D28-B404DC7DAF63</uax:String>
       </uax:Guid>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1012" BrowseName="NodeId" DataType="NodeId" ValueRank="-1">
+    <DisplayName>NodeId</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=85</Reference>
+    </References>
+    <Value>
+      <uax:NodeId>
+        <uax:Identifier>ns=1;i=1234</uax:Identifier>
+      </uax:NodeId>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1013" BrowseName="NodeIdNs0" DataType="NodeId" ValueRank="-1">
+    <DisplayName>NodeId</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=85</Reference>
+    </References>
+    <Value>
+      <uax:NodeId>
+        <uax:Identifier>i=1234</uax:Identifier>
+      </uax:NodeId>
     </Value>
   </UAVariable>
     <UAVariable NodeId="ns=1;i=15007" BrowseName="StaticNumericNodeIdRange" DataType="i=291" ValueRank="1" ArrayDimensions="0">

--- a/backends/open62541/tests/namespaceZeroValues.xml
+++ b/backends/open62541/tests/namespaceZeroValues.xml
@@ -21,6 +21,7 @@
         <Alias Alias="LocalizedText">i=21</Alias>
         <Alias Alias="QualifiedName">i=20</Alias>
         <Alias Alias="EnumValueType">i=7594</Alias>
+        <Alias Alias="NodeId">i=17</Alias>
     </Aliases>
    <UAVariable NodeId="ns=1;i=1000" BrowseName="InputArguments" DataType="i=296" ValueRank="1" ArrayDimensions="0">
     <DisplayName>Arguments_Array</DisplayName>
@@ -290,12 +291,24 @@
       <Reference ReferenceType="HasComponent" IsForward="false">i=85</Reference>
     </References>
     <Value>
-      <QualifiedName>
-        <NamespaceIndex>2</NamespaceIndex>
-        <Name>qualifiedName</Name>
-      </QualifiedName>
+      <uax:QualifiedName>
+        <uax:NamespaceIndex>1</uax:NamespaceIndex>
+        <uax:Name>qualifiedName</uax:Name>
+      </uax:QualifiedName>
     </Value>
   </UAVariable>
+  <UAVariable NodeId="ns=1;i=1012" BrowseName="NodeId" DataType="NodeId" ValueRank="-1">
+    <DisplayName>NodeId</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">i=85</Reference>
+    </References>
+    <Value>
+      <uax:NodeId>
+        <uax:Identifier>ns=1;i=1234</uax:Identifier>
+      </uax:NodeId>
+    </Value>
+  </UAVariable>  
   <UAVariable DataType="EnumValueType" ValueRank="1" NodeId="ns=1;i=1010" ArrayDimensions="2" BrowseName="EnumValues">
         <DisplayName>EnumValues</DisplayName>
         <References>

--- a/backends/open62541/tests/subDataTypes.c
+++ b/backends/open62541/tests/subDataTypes.c
@@ -64,7 +64,7 @@ START_TEST(Server_loadNodeset)
     retval =
         UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 6004), &var);
     ck_assert_uint_eq(retval, UA_STATUSCODE_GOOD);
-    UA_NodeId test = UA_NODEID_NUMERIC(1, 234);
+    UA_NodeId test = UA_NODEID_NUMERIC(2, 234);
     ck_assert(UA_NodeId_equal(&test, (UA_NodeId*)var.data));
     UA_Variant_clear(&var);
     retval =


### PR DESCRIPTION
In Value.c there was a "TODO: translate namespaceIndex?"
In my opinion the answer should be yes. In my nodesets I'm having values that contain NodeIds, which are "poor man's references" to the nodes within the server (PubSub DataSet structures).

More details of the proposed change is included in the commit message. ServerContext.h includes some minimum documentation too.