### PR TITLE
Fix issues with ArrayDimensions

### DIFF
--- a/backends/open62541/src/import.c
+++ b/backends/open62541/src/import.c
@@ -182,16 +182,16 @@ static size_t getArrayDimensions(const char *s, UA_UInt32 **dims)
     int val = atoi(s);
     arrSize++;
     *dims = (UA_UInt32 *)malloc(sizeof(UA_UInt32));
-    *dims[0] = (UA_UInt32)val;
+    (*dims)[0] = (UA_UInt32)val;
 
-    const char *subString = strchr(s, ';');
+    const char *subString = strchr(s, ',');
 
     while (subString != NULL)
     {
         arrSize++;
         *dims = (UA_UInt32 *)realloc(*dims, arrSize * sizeof(UA_UInt32));
-        *dims[arrSize - 1] = (UA_UInt32)atoi(subString + 1);
-        subString = strchr(subString + 1, ';');
+        (*dims)[arrSize - 1] = (UA_UInt32)atoi(subString + 1);
+        subString = strchr(subString + 1, ',');
     }
     return arrSize;
 }

--- a/backends/open62541/tests/valueRank.c
+++ b/backends/open62541/tests/valueRank.c
@@ -62,6 +62,21 @@ START_TEST(import_ValueRank)
               UA_Server_readValue(server, UA_NODEID_NUMERIC(2, 6006), &var));
     ck_assert(1 == *((int *)var.data));
     UA_Variant_clear(&var);
+
+    // Test import of multi-dimensional arrays.
+    // Test only ValueRank and ArrayDimensions attributes.
+    // TODO: test also imported value when importing multi-dimensional array values is supported.
+    UA_Int32 valueRank;
+    ck_assert(UA_STATUSCODE_GOOD ==
+              UA_Server_readValueRank(server, UA_NODEID_NUMERIC(2, 6007), &valueRank));
+    ck_assert(valueRank == 2);
+    UA_Variant dimensions;
+    ck_assert(UA_STATUSCODE_GOOD ==
+              UA_Server_readArrayDimensions(server, UA_NODEID_NUMERIC(2, 6007), &dimensions));
+    ck_assert(dimensions.arrayLength == 2);
+    ck_assert(((UA_Int32 *)dimensions.data)[0] == 2);
+    ck_assert(((UA_Int32 *)dimensions.data)[1] == 3);
+    UA_Variant_clear(&dimensions);
 }
 END_TEST
 

--- a/backends/open62541/tests/valueRank.xml
+++ b/backends/open62541/tests/valueRank.xml
@@ -104,4 +104,28 @@
             </uax:ListOfExtensionObject>
         </Value>
     </UAVariable>
+    <UAVariable DataType="UInt32" ValueRank="2" ArrayDimensions="2,3" NodeId="ns=1;i=6007" BrowseName="1:MultiDimensionalArray" AccessLevel="3">
+        <DisplayName>MultiDimensionalArray</DisplayName>
+        <References>
+            <Reference ReferenceType="Organizes" IsForward="false">i=85</Reference>
+            <Reference ReferenceType="HasTypeDefinition">i=63</Reference>
+        </References>
+        <!-- TODO: Example test value. To be tested when importing multi-dimensional array values is supported.
+        <Value>		
+            <uax:Matrix>
+                <uax:Dimensions>
+                    <uax:Int32>2</uax:Int32>
+                    <uax:Int32>3</uax:Int32>
+                </uax:Dimensions>
+                <uax:Elements>
+                    <uax:UInt32>1</uax:UInt32>
+                    <uax:UInt32>2</uax:UInt32>
+                    <uax:UInt32>3</uax:UInt32>
+                    <uax:UInt32>4</uax:UInt32>
+                    <uax:UInt32>5</uax:UInt32>
+                    <uax:UInt32>6</uax:UInt32>
+                </uax:Elements>
+            </uax:Matrix>
+        </Value> -->
+    </UAVariable>
 </UANodeSet>


### PR DESCRIPTION
1) According to the Nodeset2 schema, array dimensions are separated by
commas, not semicolons.

2) Array dimensions were not stored properly due to an issue with
pointer dereferenceing.

Note: Import of values of multi-dimensional arrays is not supported yet.